### PR TITLE
Return game lengths up to 3 hours for FFA (others remain at 1 hour)

### DIFF
--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStat.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStat.cs
@@ -26,36 +26,37 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.GameLengths
                     new GameLengthPerMode
                     {
                         GameMode = GameMode.GM_1v1,
-                        Lengths = CreateLengths()
+                        Lengths = CreateLengths(GameMode.GM_1v1)
                     },
                     new GameLengthPerMode
                     {
                         GameMode = GameMode.GM_2v2_AT,
-                        Lengths = CreateLengths()
+                        Lengths = CreateLengths(GameMode.GM_2v2_AT)
                     },
                     new GameLengthPerMode
                     {
                         GameMode = GameMode.GM_4v4,
-                        Lengths = CreateLengths()
+                        Lengths = CreateLengths(GameMode.GM_4v4)
                     },
                     new GameLengthPerMode
                     {
                         GameMode = GameMode.FFA,
-                        Lengths = CreateLengths()
+                        Lengths = CreateLengths(GameMode.FFA)
                     },
                     new GameLengthPerMode
                     {
                         GameMode = GameMode.GM_2v2,
-                        Lengths = CreateLengths()
+                        Lengths = CreateLengths(GameMode.GM_2v2)
                     },
                 }
             };
         }
 
-        private static List<GameLength> CreateLengths()
+        private static List<GameLength> CreateLengths(GameMode gameMode)
         {
             var lengths = new List<GameLength>();
-            for (var i = 0; i <= 120; i++)
+            var iterations = gameMode != GameMode.FFA ? 120 : 360;
+            for (var i = 0; i <= iterations; i++)
             {
                 lengths.Add(new GameLength {passedTimeInSeconds = i * 30});
             }


### PR DESCRIPTION
Trying to get my first PR in, which is meant to address this issue: https://github.com/w3champions/w3champions-ui/issues/210

I noticed that the root cause seemed to be with the data returned from https://statistic-service.w3champions.com/api/w3c-stats/games-lengths (and not the UI itself). So this should now return game lengths up to **3 hours** for **FFA** (i.e `360 * 30 sec = 180 min`), while the **other game modes** remain at **1 hour** (i.e. `120 * 30 sec = 60 min`).