### PR TITLE
Extend mmr distribution

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -58,11 +58,14 @@ namespace W3ChampionsStatisticService.PlayerProfiles
             return UpsertMany(winrate);
         }
 
-        public async Task<List<int>> LoadMmrs(int season)
+
+        public async Task<List<int>> LoadMmrs(int season, GateWay gateWay, GameMode gameMode)
         {
             var mongoCollection = CreateCollection<PlayerOverview>();
             var mmrs = await mongoCollection
-                .Find(p => p.Season == season)
+                .Find(p => p.Season == season &&
+                           p.GateWay == gateWay &&
+                           p.GameMode == gameMode)
                 .Project(p => p.MMR)
                 .ToListAsync();
             return mmrs;

--- a/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
@@ -18,7 +18,7 @@ namespace W3ChampionsStatisticService.Ports
         Task<PlayerWinLoss> LoadPlayerWinrate(string playerId, int season);
         Task<List<PlayerDetails>> LoadPlayersRaceWins(List<string> playerIds);
         Task UpsertWins(List<PlayerWinLoss> winrate);
-        Task<List<int>> LoadMmrs(int season);
+        Task<List<int>> LoadMmrs(int season, GateWay gateWay, GameMode gameMode);
         Task<List<PlayerOverallStats>> SearchForPlayer(string search);
         Task<PlayerGameModeStatPerGateway> LoadGameModeStatPerGateway(string id);
         Task UpsertPlayerGameModeStatPerGateway(PlayerGameModeStatPerGateway stat);

--- a/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using W3ChampionsStatisticService.CommonValueObjects;
 using W3ChampionsStatisticService.Ports;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution
@@ -14,9 +15,9 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution
             _playerRepository = playerRepository;
         }
 
-        public async Task<MmrStats> GetDistributions(int season)
+        public async Task<MmrStats> GetDistributions(int season, GateWay gateWay, GameMode gameMode)
         {
-            var mmrs = await _playerRepository.LoadMmrs(season);
+            var mmrs = await _playerRepository.LoadMmrs(season, gateWay, gameMode);
             var orderedMMrs = mmrs.OrderByDescending(m => m).ToList();
             var ranges = Ranges(2325, 575, 25).ToList();
             var highest = ranges.First();

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using W3ChampionsStatisticService.CommonValueObjects;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.W3ChampionsStats.HeroWinrate;
 using W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
@@ -87,9 +88,9 @@ namespace W3ChampionsStatisticService.W3ChampionsStats
         }
 
         [HttpGet("mmr-distribution")]
-        public async Task<IActionResult> GetMmrDistribution(int season)
+        public async Task<IActionResult> GetMmrDistribution(int season, GateWay gateWay = GateWay.Europe, GameMode gameMode = GameMode.GM_1v1)
         {
-            var mmrs = await _mmrDistributionHandler.GetDistributions(season);
+            var mmrs = await _mmrDistributionHandler.GetDistributions(season, gateWay, gameMode);
             return Ok(mmrs);
         }
 

--- a/WC3ChampionsStatisticService.UnitTests/PlayerOverviewTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerOverviewTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -5,6 +6,7 @@ using NUnit.Framework;
 using W3ChampionsStatisticService.CommonValueObjects;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
 
 namespace WC3ChampionsStatisticService.UnitTests
 {
@@ -266,5 +268,52 @@ namespace WC3ChampionsStatisticService.UnitTests
             Assert.AreEqual(Race.HU, playerProfile1.Race);
             Assert.AreEqual(Race.NE, playerProfile2.Race);
         }
+
+        [Test]
+        public async Task PlayerStats_LoadMMRsByValidEnumValues()
+        {
+
+            var testing_season = 0;
+            var playerRepository = new PlayerRepository(MongoClient);
+            var playOverviewHandler = new PlayOverviewHandler(playerRepository);
+
+            var mmrDistributionHandler = new MmrDistributionHandler(playerRepository);
+
+            var gateWayValues = Enum.GetValues(typeof(GateWay));
+            var gameModeValues = Enum.GetValues(typeof(GameMode));
+        
+            foreach (GateWay gateWay in gateWayValues)
+            {
+                //skip undefinded value of ENums
+                if (gateWay == GateWay.Undefined) continue;
+                foreach (GameMode gameMode in gameModeValues)
+                {
+                    if (gameMode == GameMode.Undefined || gameMode ==GameMode.GM_2v2 || gameMode == GameMode.GM_2v2_AT ) continue;
+
+                    var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
+                    matchFinishedEvent1.match.players[0].battleTag = "peter#123";
+                    matchFinishedEvent1.match.season = testing_season;
+                    matchFinishedEvent1.match.players[0].race = Race.HU;
+                    matchFinishedEvent1.match.gateway = gateWay;
+                    matchFinishedEvent1.match.gameMode = gameMode;
+
+                    var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
+                    matchFinishedEvent2.match.players[0].battleTag = "peter#123";
+                    matchFinishedEvent2.match.season = testing_season;
+                    matchFinishedEvent2.match.players[0].race = Race.NE;
+                    matchFinishedEvent2.match.gateway = gateWay;
+                    matchFinishedEvent2.match.gameMode = gameMode;
+
+                    await playOverviewHandler.Update(matchFinishedEvent1);
+                    await playOverviewHandler.Update(matchFinishedEvent2);
+
+
+                    var distribution = await mmrDistributionHandler.GetDistributions(testing_season, gateWay, gameMode);
+                    Assert.IsNotNull(distribution);
+                }
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
I extended the Load  mrrs function. Now its possible to have parameters of Gateway and Gamemode in the API.
So the issue in the UI can be handled https://github.com/w3champions/w3champions-ui/issues/242

The default values are Gateway Europe and Gamemode 1v1 as this seemed to be (or should be) the default. So it should be backward compatible with any functions in UI at the moment.

All tests in my projects passed, but it seems LoadMMRsDitribution function is not involved in any test.
Also tested on local Mongodb and works.

If you want to have any further changes, let me know pls.

When there are cases the old function is still needed I could change it to an overload function.
