### PR TITLE
MMR Timeline for individual players

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimeline.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using W3ChampionsStatisticService.CommonValueObjects;
+using System.Linq;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats
+{
+    public class PlayerMmrTimeline : IIdentifiable
+    {
+        public PlayerMmrTimeline(string battleTag, Race race, GateWay gateWay, int season)
+        {
+            Id = $"{season}_{battleTag}_@{gateWay}_{race}";
+            BattleTag = battleTag;
+            Race = Race;
+            GateWay = gateWay;
+            Season = season;
+        }
+        public List<MmrAtTime> MmrAtTimes = new List<MmrAtTime>();
+        public string BattleTag { get; set; }
+        public Race Race { get; set; }
+        public GateWay GateWay { get; set; }
+        public int Season { get; set; }
+        public string Id { get; set; }
+
+    }
+
+    public class MmrAtTime
+    {
+        public MmrAtTime(int mmr, DateTimeOffset mmrTime) {
+            Mmr = mmr;
+            MmrTime = mmrTime;
+        }
+        public int Mmr;
+        public DateTimeOffset MmrTime;
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimelineHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimelineHandler.cs
@@ -30,7 +30,7 @@ namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats
                 var mmrTimeline = await _playerRepository.LoadPlayerMmrTimeline(player.battleTag, player.race, match.gateway, match.season)
                            ?? await CreateMmrTimeline(match, player);
 
-                // Unclear: When previous line used CreateMmrTimeline, is the new match already added to the timeline or not???
+                // Unclear: When previous line used CreateMmrTimeline(), is the new match already added to the timeline or not?
                 mmrTimeline.MmrAtTimes.Add(new MmrAtTime(
                     mmr: (int)player.mmr.rating,
                     mmrTime: DateTimeOffset.FromUnixTimeMilliseconds(match.endTime)));;
@@ -54,7 +54,7 @@ namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats
                     {
                         if (p.BattleTag == player.battleTag)
                         {
-                            // Correct sorting?
+                            // Is this the correct sorting?
                             mmrTimeline.MmrAtTimes.Add(new MmrAtTime(p.CurrentMmr, m.EndTime));
                         }
                     }

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimelineHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrTimelineHandler.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.Matches;
+using W3ChampionsStatisticService.PadEvents;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats
+{
+    public class PlayerMmrTimelineHandler : IReadModelHandler
+    {
+        private readonly IPlayerRepository _playerRepository;
+        private readonly IMatchRepository _matchRepository;
+
+        public PlayerMmrTimelineHandler(
+            IPlayerRepository playerRepository,
+            IMatchRepository matchRepository
+            )
+        {
+            _playerRepository = playerRepository;
+            _matchRepository = matchRepository;
+        }
+
+        public async Task Update(MatchFinishedEvent nextEvent) 
+        {
+            var match = nextEvent.match;
+
+            foreach (var player in match.players)
+            {
+                var mmrTimeline = await _playerRepository.LoadPlayerMmrTimeline(player.battleTag, player.race, match.gateway, match.season)
+                           ?? await CreateMmrTimeline(match, player);
+
+                // Unclear: When previous line used CreateMmrTimeline, is the new match already added to the timeline or not???
+                mmrTimeline.MmrAtTimes.Add(new MmrAtTime(
+                    mmr: (int)player.mmr.rating,
+                    mmrTime: DateTimeOffset.FromUnixTimeMilliseconds(match.endTime)));;
+
+                await _playerRepository.UpsertPlayerMmrTimeline(mmrTimeline);
+            }
+        }
+
+        public async Task<PlayerMmrTimeline> CreateMmrTimeline(Match match, PlayerMMrChange player)
+        {
+            var count = await _matchRepository.CountFor(player.battleTag, null, match.gateway, match.gameMode, match.season);
+            int pageSize = (int)count;
+            var matches = await _matchRepository.LoadFor(player.battleTag, null, match.gateway, match.gameMode, pageSize, 0, match.season);
+            PlayerMmrTimeline mmrTimeline = new PlayerMmrTimeline(player.battleTag, player.race, match.gateway, match.season);
+            // Is there a better way to traverse through this?
+            foreach (Matchup m in matches)
+            {
+                foreach(Team t in m.Teams)
+                {
+                    foreach (PlayerOverviewMatches p in t.Players)
+                    {
+                        if (p.BattleTag == player.battleTag)
+                        {
+                            // Correct sorting?
+                            mmrTimeline.MmrAtTimes.Add(new MmrAtTime(p.CurrentMmr, m.EndTime));
+                        }
+                    }
+                }
+            }
+            return mmrTimeline;
+        }
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -201,5 +201,15 @@ namespace W3ChampionsStatisticService.PlayerProfiles
 
             return result;
         }
+
+        public Task<PlayerMmrTimeline> LoadPlayerMmrTimeline(string battleTag, Race race, GateWay gateWay, int season)
+        {
+            return LoadFirst<PlayerMmrTimeline>($"{season}_{battleTag}_@{gateWay}_{race}");
+        }
+
+        public Task UpsertPlayerMmrTimeline(PlayerMmrTimeline mmrTimeline)
+        {
+            return Upsert(mmrTimeline);
+        }
     }
 }

--- a/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
@@ -27,5 +27,7 @@ namespace W3ChampionsStatisticService.Ports
         Task<PlayerRaceStatPerGateway> LoadRaceStatPerGateway(string battleTag, Race race, GateWay gateWay, int season);
         Task UpsertPlayerRaceStat(PlayerRaceStatPerGateway stat);
         float? GetQuantileForPlayer(List<PlayerId> playerIds, GateWay gateWay, GameMode gameMode, Race? race, int season);
+        Task<PlayerMmrTimeline> LoadPlayerMmrTimeline(string battleTag, Race race, GateWay gateWay, int season);
+        Task UpsertPlayerMmrTimeline(PlayerMmrTimeline mmrTimeline);
     }
 }

--- a/W3ChampionsStatisticService/Startup.cs
+++ b/W3ChampionsStatisticService/Startup.cs
@@ -17,6 +17,7 @@ using W3ChampionsStatisticService.PadEvents.PadSync;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
+using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 using W3ChampionsStatisticService.PlayerStats;
 using W3ChampionsStatisticService.PlayerStats.HeroStats;
@@ -112,6 +113,7 @@ namespace W3ChampionsStatisticService
                 services.AddReadModelService<PlayerHeroStatsHandler>();
                 services.AddReadModelService<PlayerGameModeStatPerGatewayHandler>();
                 services.AddReadModelService<PlayerRaceStatPerGatewayHandler>();
+                services.AddReadModelService<PlayerMmrTimelineHandler>();
 
                 // Generell Stats
                 services.AddReadModelService<GamesPerDayHandler>();

--- a/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
@@ -315,52 +315,28 @@ namespace WC3ChampionsStatisticService.UnitTests
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
             matchFinishedEvent1.match.endTime = 1585701559200; 
-            matchFinishedEvent1.match.season = 1;
-            matchFinishedEvent1.match.players[0].battleTag = "peter#123";
             matchFinishedEvent1.match.players[0].race = Race.OC;
             matchFinishedEvent1.match.players[1].race = Race.NE;
-            matchFinishedEvent1.match.players[1].battleTag = "wolf#456";
 
             matchFinishedEvent2.match.endTime = 1585692047363;
-            matchFinishedEvent2.match.season = 1;
-            matchFinishedEvent2.match.players[0].battleTag = "peter#123";
-            matchFinishedEvent2.match.players[1].battleTag = "wolf#456";
             matchFinishedEvent2.match.players[0].won = false;
             matchFinishedEvent2.match.players[0].race = Race.OC;
             matchFinishedEvent2.match.players[1].won = true;
             matchFinishedEvent2.match.players[1].race = Race.NE;
 
-            // Needed?
-            //await InsertMatchEvent(matchFinishedEvent1);
-            //await InsertMatchEvent(matchFinishedEvent2);
-
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
 
-            var matches = await matchRepository.LoadFor("peter#123");
-
             var ev = TestDtoHelper.CreateFakeEvent();
             ev.match.endTime = 1604612998269;
-            ev.match.season = 1;
-            ev.match.players[0].battleTag = "peter#123";
-            ev.match.players[0].won = true;
             ev.match.players[0].race = Race.OC;
-
-            ev.match.players[1].battleTag = "wolf#456";
-            ev.match.players[1].won = false;
             ev.match.players[1].race = Race.NE;
 
             await handler.Update(ev);
 
             var playerMmrTimeline = await playerRepository.LoadPlayerMmrTimeline("peter#123", Race.OC, GateWay.Europe, 1);
-
+            // Todo: add some more content based asserts for the timeline
             Assert.IsNotNull(playerMmrTimeline);
-
-            //var loser = await playerRepository.LoadGameModeStatPerGateway("wolf#456", GateWay.Europe, 1);
-            //Assert.AreEqual(1, winnerStatGateWay.First(x => x.GameMode == GameMode.GM_1v1).Wins);
-
-            //Assert.AreEqual(1, loser.First(x => x.GameMode == GameMode.GM_1v1).Losses);
-            //Assert.AreEqual(0, loser.First(x => x.GameMode == GameMode.GM_1v1).Wins);
         }
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3ChampionsStatisticService.CommonValueObjects;
+using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
+using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 
 namespace WC3ChampionsStatisticService.UnitTests
@@ -300,6 +302,65 @@ namespace WC3ChampionsStatisticService.UnitTests
 
             Assert.AreEqual(1, loser3.First(x => x.GameMode == GameMode.FFA).Losses);
             Assert.AreEqual(0, loser3.First(x => x.GameMode == GameMode.FFA).Wins);
+        }
+
+        [Test]
+        public async Task Player_UpdateMmrTimeline()
+        {
+            var playerRepository = new PlayerRepository(MongoClient);
+            var matchRepository = new MatchRepository(MongoClient);
+            await matchRepository.EnsureIndices();
+            var handler = new PlayerMmrTimelineHandler(playerRepository, matchRepository);
+            var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
+            var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
+
+            matchFinishedEvent1.match.endTime = 1585701559200; 
+            matchFinishedEvent1.match.season = 1;
+            matchFinishedEvent1.match.players[0].battleTag = "peter#123";
+            matchFinishedEvent1.match.players[0].race = Race.OC;
+            matchFinishedEvent1.match.players[1].race = Race.NE;
+            matchFinishedEvent1.match.players[1].battleTag = "wolf#456";
+
+            matchFinishedEvent2.match.endTime = 1585692047363;
+            matchFinishedEvent2.match.season = 1;
+            matchFinishedEvent2.match.players[0].battleTag = "peter#123";
+            matchFinishedEvent2.match.players[1].battleTag = "wolf#456";
+            matchFinishedEvent2.match.players[0].won = false;
+            matchFinishedEvent2.match.players[0].race = Race.OC;
+            matchFinishedEvent2.match.players[1].won = true;
+            matchFinishedEvent2.match.players[1].race = Race.NE;
+
+            // Needed?
+            //await InsertMatchEvent(matchFinishedEvent1);
+            //await InsertMatchEvent(matchFinishedEvent2);
+
+            await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
+            await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
+
+            var matches = await matchRepository.LoadFor("peter#123");
+
+            var ev = TestDtoHelper.CreateFakeEvent();
+            ev.match.endTime = 1604612998269;
+            ev.match.season = 1;
+            ev.match.players[0].battleTag = "peter#123";
+            ev.match.players[0].won = true;
+            ev.match.players[0].race = Race.OC;
+
+            ev.match.players[1].battleTag = "wolf#456";
+            ev.match.players[1].won = false;
+            ev.match.players[1].race = Race.NE;
+
+            await handler.Update(ev);
+
+            var playerMmrTimeline = await playerRepository.LoadPlayerMmrTimeline("peter#123", Race.OC, GateWay.Europe, 1);
+
+            Assert.IsNotNull(playerMmrTimeline);
+
+            //var loser = await playerRepository.LoadGameModeStatPerGateway("wolf#456", GateWay.Europe, 1);
+            //Assert.AreEqual(1, winnerStatGateWay.First(x => x.GameMode == GameMode.GM_1v1).Wins);
+
+            //Assert.AreEqual(1, loser.First(x => x.GameMode == GameMode.GM_1v1).Losses);
+            //Assert.AreEqual(0, loser.First(x => x.GameMode == GameMode.GM_1v1).Wins);
         }
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerTests.cs
@@ -334,7 +334,7 @@ namespace WC3ChampionsStatisticService.UnitTests
 
             await handler.Update(ev);
 
-            var playerMmrTimeline = await playerRepository.LoadPlayerMmrTimeline("peter#123", Race.OC, GateWay.Europe, 1);
+            var playerMmrTimeline = await playerRepository.LoadPlayerMmrTimeline("peter#123", Race.OC, GateWay.Europe, 0);
             // Todo: add some more content based asserts for the timeline
             Assert.IsNotNull(playerMmrTimeline);
         }


### PR DESCRIPTION
This relates to issue #215 in UI (https://github.com/w3champions/w3champions-ui/issues/215)

The goal is to create an interface for the frontend to load MMR data to create a graph. With the parameters battletag, race, gateway and season, specific data could be easily queried from the backend to display graphs for various constallations.

As I'm new to the project, I'm not sure whether the mmr values used are the correct ones. In the "PlayerMmrTimelineHandler", once im using "Match" (Update()) and once "Matchup" (CreateMmrTimeline()) to get the mmr values. Not sure if this is problematic. From "Match" I can get a "PlayerMMrChange", which has both "mmr" and "updatedMmr". Which one to use?

I added a test, but I'm getting weird values for the mmr numbers. They seem to be random, not sure why.

Feedback would be greatly appreciated!