### PR TITLE
Add random race to matchup players.

### DIFF
--- a/W3ChampionsStatisticService/CommonValueObjects/Race.cs
+++ b/W3ChampionsStatisticService/CommonValueObjects/Race.cs
@@ -20,21 +20,4 @@ namespace W3ChampionsStatisticService.CommonValueObjects
         UD = 3,
         NE = 4,
     }
-
-    public static class Extensions
-    {
-        static Dictionary<RaceId, Race> raceIdMap = new Dictionary<RaceId, Race>() {
-            { RaceId.RnD, Race.RnD },
-            { RaceId.HU, Race.HU },
-            { RaceId.OC, Race.OC },
-            { RaceId.NE, Race.NE },
-            { RaceId.UD, Race.UD }
-        };
-
-        public static Race FromRaceId(this Race race, RaceId raceId)
-        {
-            return raceIdMap[raceId];
-        }
-    }
-
 }

--- a/W3ChampionsStatisticService/CommonValueObjects/Race.cs
+++ b/W3ChampionsStatisticService/CommonValueObjects/Race.cs
@@ -1,4 +1,6 @@
-﻿namespace W3ChampionsStatisticService.CommonValueObjects
+﻿using System.Collections.Generic;
+
+namespace W3ChampionsStatisticService.CommonValueObjects
 {
     public enum Race
     {
@@ -9,4 +11,30 @@
         UD = 8,
         Total = 16
     }
+
+    public enum RaceId
+    {
+        RnD = 0,
+        HU = 1,
+        OC = 2,
+        UD = 3,
+        NE = 4,
+    }
+
+    public static class Extensions
+    {
+        static Dictionary<RaceId, Race> raceIdMap = new Dictionary<RaceId, Race>() {
+            { RaceId.RnD, Race.RnD },
+            { RaceId.HU, Race.HU },
+            { RaceId.OC, Race.OC },
+            { RaceId.NE, Race.NE },
+            { RaceId.UD, Race.UD }
+        };
+
+        public static Race FromRaceId(this Race race, RaceId raceId)
+        {
+            return raceIdMap[raceId];
+        }
+    }
+
 }

--- a/W3ChampionsStatisticService/CommonValueObjects/RaceExtensions.cs
+++ b/W3ChampionsStatisticService/CommonValueObjects/RaceExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace W3ChampionsStatisticService.CommonValueObjects
+{
+    public static class RaceExtensions
+    {
+        static Dictionary<RaceId, Race> raceIdMap = new Dictionary<RaceId, Race>() {
+            { RaceId.RnD, Race.RnD },
+            { RaceId.HU, Race.HU },
+            { RaceId.OC, Race.OC },
+            { RaceId.NE, Race.NE },
+            { RaceId.UD, Race.UD }
+        };
+
+        public static Race FromRaceId(this Race race, RaceId raceId)
+        {
+            return raceIdMap[raceId];
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -68,16 +68,30 @@ namespace W3ChampionsStatisticService.Matches
                 .ThenBy(x => x.team)
                 .ToList();
 
-            foreach (var resultPlayer in matchFinishedEvent.result.players)
+            if (matchFinishedEvent.result == null)
             {
-                var matchPlayer = players.First(p => p.battleTag == resultPlayer.battleTag); 
-
-                // If the player chose random for the match,
-                // set their actual randomized race from the result.
-                matchPlayer.rndRace = matchPlayer.race == Race.RnD
-                    ? matchPlayer.race.FromRaceId((RaceId)resultPlayer.raceId)
-                    : null;
+                foreach (var matchPlayer in players)
+                {
+                    // If no result, set each random players random race
+                    // to random, as we have no way to determine their played
+                    // race.
+                    matchPlayer.rndRace = matchPlayer.race == Race.RnD ? Race.RnD : null;
+                }
             }
+            else
+            {
+                foreach (var resultPlayer in matchFinishedEvent.result.players)
+                {
+                    var matchPlayer = players.First(p => p.battleTag == resultPlayer.battleTag);
+
+                    // If the player chose random for the match,
+                    // set their actual randomized race from the result.
+                    matchPlayer.rndRace = matchPlayer.race == Race.RnD
+                        ? matchPlayer.race.FromRaceId((RaceId)resultPlayer.raceId)
+                        : null;
+                }
+            }
+
 
             var teamGroups = SplitPlayersIntoTeams(players, match.gameMode);
 

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -68,6 +68,15 @@ namespace W3ChampionsStatisticService.Matches
                 .ThenBy(x => x.team)
                 .ToList();
 
+            foreach (var player in matchFinishedEvent.result.players)
+            {
+                var matchPlayer = players.First(p => p.battleTag == player.battleTag);
+
+                Race? rndRace = determineRandomRace(player, matchPlayer);
+
+                matchPlayer.rndRace = rndRace;
+            }
+
             var teamGroups = SplitPlayersIntoTeams(players, match.gameMode);
 
             foreach (var team in teamGroups)
@@ -81,6 +90,44 @@ namespace W3ChampionsStatisticService.Matches
             SetTeamPlayers(result);
 
             return result;
+        }
+
+        private static Race? determineRandomRace(PlayerBlizzard player, PlayerMMrChange matchPlayer)
+        {
+            Race? rndRace = null;
+            if (matchPlayer.race == Race.RnD)
+            {
+                var huHeroes = new List<string> { "archmage", "mountainking", "paladin", "sorceror" };
+                var ocHeroes = new List<string> { "beastmaster", "blademaster", "taurenchieftain", "shadowhunter" };
+                var neHeroes = new List<string> { "priestessofthemoon", "keeperofthegrove", "demonhunter", "warden" };
+                var udHeroes = new List<string> { "lich", "deathknight", "cryptlord", "dreadlords" };
+
+                foreach (var hero in player.heroes.Select(h => h.icon.ParseReforgedName()))
+                {
+                    if (huHeroes.Any(humanHero => humanHero == hero))
+                    {
+                        rndRace = Race.HU;
+                    }
+                    else if (ocHeroes.Any(orcHero => orcHero == hero))
+                    {
+                        rndRace = Race.OC;
+                    }
+                    else if (neHeroes.Any(neHero => neHero == hero))
+                    {
+                        rndRace = Race.NE;
+                    }
+                    else if (udHeroes.Any(udHero => udHero == hero))
+                    {
+                        rndRace = Race.UD;
+                    }
+                    else
+                    {
+                        rndRace = Race.RnD;
+                    }
+                }
+            }
+
+            return rndRace;
         }
 
         protected static Dictionary<int, List<T>> SplitPlayersIntoTeams<T>(List<T> players, GameMode gameMode)
@@ -169,7 +216,8 @@ namespace W3ChampionsStatisticService.Matches
                 CurrentMmr = (int?)w.updatedMmr?.rating ?? (int)w.mmr.rating,
                 OldMmr = (int)w.mmr.rating,
                 Won = w.won,
-                Race = w.race
+                Race = w.race,
+                RndRace = w.rndRace
             });
         }
     }

--- a/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
+++ b/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
@@ -5,6 +5,7 @@ namespace W3ChampionsStatisticService.Matches
     public class PlayerOverviewMatches
     {
         public Race Race { get; set; }
+        public Race? RndRace { get; set; }
         public int OldMmr { get; set; }
         public int CurrentMmr { get; set; }
         public string BattleTag { get; set; }

--- a/W3ChampionsStatisticService/PadEvents/MatchEventDtos.cs
+++ b/W3ChampionsStatisticService/PadEvents/MatchEventDtos.cs
@@ -22,6 +22,7 @@ namespace W3ChampionsStatisticService.PadEvents
         public Mmr updatedMmr { get; set; }
         public Ranking updatedRanking { get; set; }
         public string atTeamId { get; set; }
+        public Race? rndRace { get; set; }
 
         public bool IsAt
         {

--- a/WC3ChampionsStatisticService.UnitTests/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/MatchupDetailTest.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
+using W3ChampionsStatisticService.CommonValueObjects;
 
 namespace WC3ChampionsStatisticService.UnitTests
 {
@@ -42,6 +43,33 @@ namespace WC3ChampionsStatisticService.UnitTests
             Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
             Assert.AreEqual("Archmage", result.PlayerScores[0].Heroes[0].icon);
             Assert.AreEqual("Warden", result.PlayerScores[1].Heroes[0].icon);
+        }
+
+        [Test]
+        public async Task LoadDetails_DetermineRandomRace()
+        {
+            var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
+            matchFinishedEvent.match.id = "nmhcCLaRc7";
+            matchFinishedEvent.Id = ObjectId.GenerateNewId();
+
+            // Set race to random.
+            matchFinishedEvent.result.players[0].raceId = (int)Race.RnD;
+            matchFinishedEvent.match.players.Find(p => p.battleTag == matchFinishedEvent.result.players[0].battleTag).race = Race.RnD;
+
+            matchFinishedEvent.result.players[0].heroes[0].icon = "archmage";
+
+            await InsertMatchEvent(matchFinishedEvent);
+
+            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+
+            await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
+
+            var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+
+            Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
+            Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].icon);
+            Assert.AreEqual(Race.RnD, result.Match.Teams[0].Players[0].Race);
+            Assert.AreEqual(Race.HU, result.Match.Teams[0].Players[0].RndRace);
         }
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/TestDtoHelper.cs
@@ -32,6 +32,9 @@ namespace WC3ChampionsStatisticService.UnitTests
             fakeEvent.match.players.Last().battleTag = name2;
             fakeEvent.match.players.Last().won = false;
 
+            fakeEvent.result.players.First().battleTag = name1;
+            fakeEvent.result.players.Last().battleTag = name2;
+
             return fakeEvent;
         }
 


### PR DESCRIPTION
Use the player's hero selection to determine, if possible,
which race they were assigned from the random selection.
Assigned to a new member property, so that it can be used
separately for statistical computations/display. If the
player's race is not random, then null is assigned to the
random race member. If it cannot be determined which race
was assigned, then random is set for both the player race
as well as the random race.

First step required for handling w3champions/w3champions-ui#281
sanely in multiple UI components. Also, computed in the record so
that statistics can be computed at a later time.

Does not backfill previous matches.