### PR TITLE
Add handling for missing leagues in season 0.

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
@@ -53,11 +53,21 @@ namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats
             {
                 if (rank.RankNumber == 0) return;
                 var leagueConstellation = allLeagues.Single(l => l.Gateway == rank.Gateway && l.Season == rank.Season && l.GameMode == rank.GameMode);
-                var league = leagueConstellation.Leagues.Single(l => l.Id == rank.League);
+
+                // There are some Ranks with Leagues that do not exist in
+                // Season 0 LeagueConstellations, which we should ignore.
+                // (Data integrity issue)
+                var league = leagueConstellation.Season == 0
+                    ? leagueConstellation.Leagues.SingleOrDefault(l => l.Id == rank.League)
+                    : leagueConstellation.Leagues.Single(l => l.Id == rank.League);
+
+                if (league == null) return;
+
 
                 var gameModeStat = player.SingleOrDefault(g => g.Id == rank.Id);
 
                 if (gameModeStat == null) return;
+            
 
                 gameModeStat.Division = league.Division;
                 gameModeStat.LeagueOrder = league.Order;


### PR DESCRIPTION
There are some ranks in season 0, that do not have a league
for the corresponding league constellation, e.g. 0_Europe_GM_1v1.
Rather than rely on the try/catch to catch the Linq exception on
the Single call, use SingleOrDefault specifically for season 0,
so that we avoid the bloating of the logs, but can still catch
exceptions on later seasons.

should resolve w3champions/w3champions-ui#287